### PR TITLE
[pip] move the external requirement into the setup

### DIFF
--- a/aiosocks/connector.py
+++ b/aiosocks/connector.py
@@ -11,12 +11,6 @@ from . import create_connection
 __all__ = ('ProxyConnector', 'ProxyClientRequest')
 
 
-from distutils.version import StrictVersion
-
-if StrictVersion(aiohttp.__version__) < StrictVersion('2.3.2'):
-    raise RuntimeError('aiosocks.connector depends on aiohttp 2.3.2+')
-
-
 class ProxyClientRequest(aiohttp.ClientRequest):
     def update_proxy(self, proxy, proxy_auth, proxy_headers):
         if proxy and proxy.scheme not in ['http', 'socks4', 'socks5']:

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,8 @@ setup(
 
         description='SOCKS proxy client for asyncio and aiohttp',
         long_description=open("README.rst").read(),
-        packages=['aiosocks']
+        packages=['aiosocks'],
+        install_requires=[
+            'aiohttp>=2.3.2',
+        ],
 )


### PR DESCRIPTION
It is possible to install `aiosocks` with an `aiohttp` version below `2.3.2`. This should not be possible and `pip` can help us here.

See this demo using a new virtual environment running in `/tmp/001`:
```
$ python3 -m venv /tmp/001 && /tmp/001/bin/pip install -q aiohttp==2.3.0 && \
  /tmp/001/bin/pip install -q aiosocks && \
  /tmp/001/bin/python3 -c "import aiosocks.connector"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/001/lib/python3.5/site-packages/aiosocks/connector.py", line 17, in <module>
    raise RuntimeError('aiosocks.connector depends on aiohttp 2.3.2+')
RuntimeError: aiosocks.connector depends on aiohttp 2.3.2+
$ echo $?
1

$ rm -rf /tmp/001/

$ python3 -m venv /tmp/001 && /tmp/001/bin/pip install -q aiohttp==2.3.0 && \
  /tmp/001/bin/pip install -q git+https://github.com/das7pad/aiosocks@dbbc && \
  /tmp/001/bin/python3 -c "import aiosocks.connector"
$ echo $?
0
```

Packages using `pip-compile` or similar rely on a version specifier of requirements to choose a working version mix of external packages.